### PR TITLE
Handle unicode characters gracefully in python 2

### DIFF
--- a/src/onelogin/saml2/compat.py
+++ b/src/onelogin/saml2/compat.py
@@ -39,6 +39,8 @@ if isinstance(b'', type('')):  # py 2.x
 
     def to_bytes(data):
         """ return bytes """
+        if isinstance(data, unicode):
+            return data.encode("utf8")
         return str(data)
 
 else:  # py 3.x


### PR DESCRIPTION
Hello there! We've come across some bugs like the following using this library's `add_sign` function:
```
File /opt/virtualenv/monolith/local/lib/python2.7/site-packages/onelogin/saml2/utils.py line 740 in add_sign
elem = OneLogin_Saml2_XML.to_etree(xml)
File /opt/virtualenv/monolith/local/lib/python2.7/site-packages/onelogin/saml2/xml_utils.py line 68 in to_etree
return OneLogin_Saml2_XML._parse_etree(compat.to_bytes(xml), forbid_dtd=True)
File /opt/virtualenv/monolith/local/lib/python2.7/site-packages/onelogin/saml2/compat.py line 42 in to_bytes
return str(data)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xc9' in position 2593: ordinal not in range(128)
```
It looks like we're getting this error when a user's name or other data has a non-ascii character that goes through this function - and we're still using Python 2 for this.

I believe my fix should allow for gracefully handling unicode characters in Python 2. Let me know if you have any questions/concerns.