### PR TITLE
Remove lxml version restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Installation
 
  * python 2.7 // python 3.6
  * [xmlsec](https://pypi.python.org/pypi/xmlsec) Python bindings for the XML Security Library.
+ * [lxml](https://pypi.python.org/pypi/lxml) Python bindings for the libxml2 and libxslt libraries.
  * [isodate](https://pypi.python.org/pypi/isodate) An ISO 8601 date/time/
  duration parser and formatter
 
@@ -114,6 +115,14 @@ $ pip install python3-saml
 ```
 
 If you want to know how a project can handle python packages review this [guide](https://packaging.python.org/en/latest/tutorial.html) and review this [sampleproject](https://github.com/pypa/sampleproject)
+
+#### NOTE ####
+To avoid ``libxml2`` library version incompatibilities between ``xmlsec`` and ``lxml`` it is recommended that ``lxml`` is not installed from binary.
+
+This can be ensured by executing:
+```
+$ pip install --force-reinstall --no-binary lxml lxml
+```
 
 Security Warning
 ----------------

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     },
     test_suite='tests',
     install_requires=[
-        'lxml<4.7.1',
+        'lxml>=4.6.5',
         'isodate>=0.6.1',
         'xmlsec>=1.3.9'
     ],

--- a/tests/src/OneLogin/saml2_tests/xml_utils_test.py
+++ b/tests/src/OneLogin/saml2_tests/xml_utils_test.py
@@ -3,6 +3,7 @@
 
 import json
 import unittest
+import xmlsec
 
 from base64 import b64decode
 from lxml import etree
@@ -31,6 +32,29 @@ class TestOneLoginSaml2Xml(unittest.TestCase):
         content = f.read()
         f.close()
         return content
+
+    def testLibxml2(self):
+        """
+        Tests that libxml2 versions used by xmlsec and lxml are compatible
+
+        If this test fails, reinstall lxml without using binary to ensure it is
+        linked to same version of libxml2 as xmlsec:
+        pip install --force-reinstall --no-binary lxml lxml
+
+        See https://bugs.launchpad.net/lxml/+bug/1960668
+        """
+        env = etree.fromstring('<xml></xml>')
+        sig = xmlsec.template.create(
+            env,
+            xmlsec.Transform.EXCL_C14N,
+            xmlsec.Transform.RSA_SHA256,
+            ns="ds"
+        )
+
+        ds = etree.QName(sig).namespace
+        cm = sig.find(".//{%s}CanonicalizationMethod" % ds)
+
+        self.assertIsNotNone(cm)
 
     def testValidateXML(self):
         """


### PR DESCRIPTION
Add workaroud for the issue lxml version was originally pinned for.

Addresses #292 with a workaround (https://github.com/onelogin/python3-saml/issues/292#issuecomment-1002604291) that does not require pinning lxml version, so newer lxml can be used with CVE vulnerability fixes.
Fixes #319

Untested as I do not have a testcase for the original failure, but I want to use python3-saml without having to downgrade lxml.

For other reports of the underlying issue see also:
https://bugs.launchpad.net/lxml/+bug/1960668
https://mail.python.org/archives/list/lxml@python.org/thread/SCMXQYGN7CQMSPJI3PEW2YBT4YZKNML2/

EDIT: this PR now just removes the version restriction and documents how to avoid the libxml2 version incompatibilities following investigation into cause of the issue, no workarounds