### PR TITLE
Fix build-system in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,11 +77,7 @@ test = ["flake8", "freezegun", "pytest", "coverage"]
 #sphinx = "*"
 
 [build-system]
-requires = [
-  "poetry>=1.1.15",
-  "setuptools >= 40.1.0",
-  "wheel"
-]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Fix the `build-system.requires` key to specify `poetry-core` rather than `poetry` as the correct package providing `poetry.core.*` backend. Remove `setuptools` and `wheel` requirements since they are not used when building via the PEP517 backend.