### PR TITLE
Issue #364: Some urls come with 403 response

### DIFF
--- a/src/onelogin/saml2/idp_metadata_parser.py
+++ b/src/onelogin/saml2/idp_metadata_parser.py
@@ -27,7 +27,7 @@ class OneLogin_Saml2_IdPMetadataParser(object):
     """
 
     @classmethod
-    def get_metadata(cls, url, validate_cert=True, timeout=None):
+    def get_metadata(cls, url, validate_cert=True, timeout=None, headers=None):
         """
         Gets the metadata XML from the provided URL
         :param url: Url where the XML of the Identity Provider Metadata is published.
@@ -38,19 +38,23 @@ class OneLogin_Saml2_IdPMetadataParser(object):
 
         :param timeout: Timeout in seconds to wait for metadata response
         :type timeout: int
+        :param headers: Extra headers to send in the request
+        :type headers: dict
 
         :returns: metadata XML
         :rtype: string
         """
         valid = False
 
+        request = urllib2.Request(url, headers=headers or {})
+
         if validate_cert:
-            response = urllib2.urlopen(url, timeout=timeout)
+            response = urllib2.urlopen(request, timeout=timeout)
         else:
             ctx = ssl.create_default_context()
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
-            response = urllib2.urlopen(url, context=ctx, timeout=timeout)
+            response = urllib2.urlopen(request, context=ctx, timeout=timeout)
         xml = response.read()
 
         if xml:
@@ -87,7 +91,7 @@ class OneLogin_Saml2_IdPMetadataParser(object):
         :returns: settings dict with extracted data
         :rtype: dict
         """
-        idp_metadata = cls.get_metadata(url, validate_cert, timeout)
+        idp_metadata = cls.get_metadata(url, validate_cert, timeout, headers=kwargs.pop('headers', None))
         return cls.parse(idp_metadata, entity_id=entity_id, **kwargs)
 
     @classmethod

--- a/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
+++ b/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
@@ -60,7 +60,6 @@ class OneLogin_Saml2_IdPMetadataParser_Test(unittest.TestCase):
         self.assertIsNotNone(data)
         self.assertIn(b'entityID=', data)
 
-
     def testParseRemote(self):
         """
         Tests the parse_remote method of the OneLogin_Saml2_IdPMetadataParser

--- a/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
+++ b/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
@@ -54,6 +54,13 @@ class OneLogin_Saml2_IdPMetadataParser_Test(unittest.TestCase):
         except URLError:
             pass
 
+    def testGetMetadataWithHeaders(self):
+        data = OneLogin_Saml2_IdPMetadataParser.get_metadata('https://samltest.id/saml/providers',
+                                                             headers={'User-Agent': 'Mozilla/5.0'})
+        self.assertIsNotNone(data)
+        self.assertIn(b'entityID=', data)
+
+
     def testParseRemote(self):
         """
         Tests the parse_remote method of the OneLogin_Saml2_IdPMetadataParser
@@ -85,6 +92,15 @@ class OneLogin_Saml2_IdPMetadataParser_Test(unittest.TestCase):
         """
         expected_settings = json.loads(expected_settings_json)
         self.assertEqual(expected_settings, data)
+
+    def testParseRemoteWithHeaders(self):
+        """
+        Tests the parse_remote method passing headers of the OneLogin_Saml2_IdPMetadataParser
+        """
+        data = OneLogin_Saml2_IdPMetadataParser.parse_remote('https://samltest.id/saml/providers')
+        self.assertEqual(data['idp']['entityId'], 'https://samltest.id/saml/idp')
+        self.assertIsNotNone(data['idp']['singleSignOnService']['url'])
+        self.assertIsNotNone(data['idp']['x509certMulti'])
 
     def testParse(self):
         """


### PR DESCRIPTION
python3-saml urllib dependency responds with 403 status to urls with default Python user-agent