### PR TITLE
test: Add test for encrypted attributes

### DIFF
--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -900,6 +900,7 @@ class OneLogin_Saml2_Response(object):
                 encrypted_data = encrypted_data_nodes[0]
                 decrypted = OneLogin_Saml2_Utils.decrypt_element(encrypted_data, key, debug=debug, inplace=True)
                 xml.replace(encrypted_assertion_nodes[0], decrypted)
+            xml = deepcopy(xml)
         return xml
 
     def get_error(self):

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -714,6 +714,23 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         response_5 = OneLogin_Saml2_Response(settings, xml_4)
         self.assertEqual(expected_attributes, response_5.get_attributes())
 
+    def testGetEncryptedAttributes(self):
+        """
+        Tests the get_attributes method of the OneLogin_Saml2_Response with an encrypted response
+        """
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON('settings8.json'))
+        xml = self.file_contents(join(self.data_path, 'responses',
+                                        'signed_message_encrypted_assertion2.xml.base64'))
+        response = OneLogin_Saml2_Response(settings, xml)
+        self.assertEqual({
+            'uid': ['smartin'],
+            'mail': ['smartin@yaco.es'],
+            'cn': ['Sixto3'],
+            'sn': ['Martin2'],
+            'phone': [],
+            'eduPersonAffiliation': ['user', 'admin'],
+        }, response.get_attributes())
+
     def testGetFriendlyAttributes(self):
         """
         Tests the get_friendlyname_attributes method of the OneLogin_Saml2_Response


### PR DESCRIPTION
When using lxml 4.5.2 - the testcases PASS
When using lxml 4.6.5 - the testcases PASS
When using lxml 4.7.1 - the testcases FAIL
When using lxml 4.8.0 - the testcases FAIL
When using lxml 4.9.3 - the testcases FAIL

This is a testcase I have written for https://github.com/SAML-Toolkits/python3-saml/issues/343
Seems like python3-saml decryption only works with older versions of lxml