### PR TITLE
Make NotOnOrAfter of Conditions accessible

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -75,6 +75,7 @@ class OneLogin_Saml2_Auth(object):
         self._last_response = None
         self._last_response_in_response_to = None
         self._last_assertion_not_on_or_after = None
+        self._conditions_not_on_or_after = None
 
     def get_settings(self):
         """
@@ -110,6 +111,7 @@ class OneLogin_Saml2_Auth(object):
         self._authenticated = True
         self._last_response_in_response_to = response.get_in_response_to()
         self._last_assertion_not_on_or_after = response.get_assertion_not_on_or_after()
+        self._conditions_not_on_or_after = response.get_conditions_not_on_or_after()
 
     def process_response(self, request_id=None):
         """
@@ -307,6 +309,14 @@ class OneLogin_Saml2_Auth(object):
         (if any) of the last assertion processed
         """
         return self._last_assertion_not_on_or_after
+
+    def get_conditions_not_on_or_after(self):
+        """
+        Returns the NotOnOrAfter value of the valid Conditions node
+        :returns: The NotOnOrAfter of the valid Conditions Node
+        :rtype: unix/posix timestamp|None
+        """
+        return self._conditions_not_on_or_after
 
     def get_errors(self):
         """

--- a/src/onelogin/saml2/response.py
+++ b/src/onelogin/saml2/response.py
@@ -550,6 +550,13 @@ class OneLogin_Saml2_Response(object):
         """
         return self.valid_scd_not_on_or_after
 
+    def get_conditions_not_on_or_after(self):
+        not_on_or_after = None
+        condition_nodes = self._query_assertion('/saml:Conditions[@NotOnOrAfter]')
+        if condition_nodes:
+            not_on_or_after = OneLogin_Saml2_Utils.parse_SAML_to_time(condition_nodes[0].get('NotOnOrAfter'))
+        return not_on_or_after
+
     def get_session_index(self):
         """
         Gets the SessionIndex from the AuthnStatement

--- a/tests/src/OneLogin/saml2_tests/auth_test.py
+++ b/tests/src/OneLogin/saml2_tests/auth_test.py
@@ -140,6 +140,27 @@ class OneLogin_Saml2_Auth_Test(unittest.TestCase):
         auth2.process_response()
         self.assertEqual(2655106621, auth2.get_session_expiration())
 
+    def testGetConditionsNotOnOrAfter(self):
+        """
+        Tests the get_conditions_not_on_or_after method of the OneLogin_Saml2_Auth class
+        """
+        settings_info = self.loadSettingsJSON()
+        auth = OneLogin_Saml2_Auth(self.get_request(), old_settings=settings_info)
+        self.assertIsNone(auth.get_conditions_not_on_or_after())
+
+        request_data = self.get_request()
+        message = self.file_contents(
+            join(self.data_path, 'responses', 'valid_response.xml.base64'))
+        del request_data['get_data']
+        request_data['post_data'] = {
+            'SAMLResponse': message
+        }
+        auth2 = OneLogin_Saml2_Auth(request_data, old_settings=self.loadSettingsJSON())
+        self.assertIsNone(auth2.get_conditions_not_on_or_after())
+
+        auth2.process_response()
+        self.assertEqual(2671081021, auth2.get_conditions_not_on_or_after())
+
     def testGetLastErrorReason(self):
         """
         Tests the get_last_error_reason method of the OneLogin_Saml2_Auth class

--- a/tests/src/OneLogin/saml2_tests/response_test.py
+++ b/tests/src/OneLogin/saml2_tests/response_test.py
@@ -1930,3 +1930,10 @@ class OneLogin_Saml2_Response_Test(unittest.TestCase):
         response.is_valid(request_data)
         self.assertIsNone(response.get_error())
         self.assertEqual(response.get_assertion_not_on_or_after(), 2671081021)
+
+    def testGetConditionNotOnOrAfter(self):
+        settings = OneLogin_Saml2_Settings(self.loadSettingsJSON())
+
+        xml = self.file_contents(join(self.data_path, 'responses', 'valid_response.xml.base64'))
+        response = OneLogin_Saml2_Response(settings, xml)
+        self.assertEqual(response.get_conditions_not_on_or_after(), 2671081021)


### PR DESCRIPTION
According to the [saml-spec](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf), the `NotOnOrAfter` attribute of the `Conditions` node indicates how long the assertions can be considered valid. In addition to `SessionNotOnOrAfter`, this could be a very useful source for SPs to use when choosing their session expiration, especially as `SessionNotOnOrAfter` is optional and not included in every message.

See also [this](https://lists.oasis-open.org/archives/saml-dev/201504/msg00001.html) message for more information.

This PR therefore adds the ability for clients to access the `NotOnOrAfter` attribute of the `Conditions` node.