### PR TITLE
Pass SLO request/response to callback

### DIFF
--- a/src/onelogin/saml2/auth.py
+++ b/src/onelogin/saml2/auth.py
@@ -170,7 +170,7 @@ class OneLogin_Saml2_Auth(object):
             else:
                 self._last_message_id = logout_response.id
                 if not keep_local_session:
-                    OneLogin_Saml2_Utils.delete_local_session(delete_session_cb)
+                    OneLogin_Saml2_Utils.delete_local_session(delete_session_cb, logout_response=logout_response)
 
         elif get_data and 'SAMLRequest' in get_data:
             logout_request = self.logout_request_class(self._settings, get_data['SAMLRequest'])
@@ -182,7 +182,7 @@ class OneLogin_Saml2_Auth(object):
                 self._errors.append('invalid_logout_request')
             else:
                 if not keep_local_session:
-                    OneLogin_Saml2_Utils.delete_local_session(delete_session_cb)
+                    OneLogin_Saml2_Utils.delete_local_session(delete_session_cb, logout_request=logout_request)
 
                 in_response_to = logout_request.id
                 self._last_message_id = logout_request.id

--- a/src/onelogin/saml2/utils.py
+++ b/src/onelogin/saml2/utils.py
@@ -484,13 +484,17 @@ class OneLogin_Saml2_Utils(object):
         return None
 
     @staticmethod
-    def delete_local_session(callback=None):
+    def delete_local_session(callback=None, logout_request=None, logout_response=None):
         """
         Deletes the local session.
         """
 
         if callback is not None:
-            callback()
+            if callback.__code__.co_argcount == 0:
+                # Legacy callback with no parameters
+                callback()
+            else:
+                callback(logout_request=logout_request, logout_response=logout_response)
 
     @staticmethod
     def calculate_x509_fingerprint(x509_cert, alg='sha1'):


### PR DESCRIPTION
This change was briefly discussed here (7 years ago!): #32 

By passing the logout request to the callback, the callback can determine the session indexes that should be destroyed. Similarly I ended up adding the logout response to the callback though I'm not 100% sure if this is useful. I'm happy to remove that part if it is not deemed useful.

I added a check for backward compatibility such that callbacks that do not accept any arguments will still work as expected.