### PR TITLE
Fetch IDP metadata using requests to support custom server certificates root CAs

### DIFF
--- a/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
+++ b/tests/src/OneLogin/saml2_tests/idp_metadata_parser_test.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-try:
-    from urllib.error import URLError
-except ImportError:
-    from urllib2 import URLError
+from urllib.error import URLError
 
 from copy import deepcopy
 import json


### PR DESCRIPTION
Closes #403

Using requests allows us to easily customize the CA_BUNDLE to use when verifying the server certificate, instead of having to disable SSL certificate verification alltogether.